### PR TITLE
Fix the example level: warn must be warning

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ application.sentryService = new modules.sentry.models.SentryService( {
 } );
 
 // Send a log message
-application.sentryService.captureMessage( 'winter is coming', 'warn' );
+application.sentryService.captureMessage( 'winter is coming', 'warning' );
 
 // Send an exception
 application.sentryService.captureException( exception=cfcatch, additionalData={ anything : 'here' } );


### PR DESCRIPTION
Fix in the readme example, the level is 'warn' but is not supported by sentry:

Error Type [warn] is invalid. Must be one of the following : [fatal, error, warning, info, debug]

changed to 'warning'
