### PR TITLE
Move to dateTimeFormat from dateConvert

### DIFF
--- a/models/SentryService.cfc
+++ b/models/SentryService.cfc
@@ -654,9 +654,8 @@ component accessors=true singleton {
 		var time 		= now();
 		var timeVars 	= {
 			"time" 			: time.getTime(),
-			"utcNowTime" 	: dateConvert("Local2UTC", time)
+			"timeStamp" 	: dateTimeFormat(time, "yyyy-mm-dd'T'HH:nn:ss", "UTC")
 		};
-		timeVars.timeStamp = dateformat(timeVars.utcNowTime, "yyyy-mm-dd") & "T" & timeFormat(timeVars.utcNowTime, "HH:mm:ss");
 		return timeVars;
 	}
 	


### PR DESCRIPTION
This is a minor change, but `dateConvert()` is "broken" on Lucee. As their docs say:

> This function only exists for compatibility reasons and should not be used. The timezone is not part of the datetime object. The function simply add/subtracts the time between the local time and the UTC from the date Object.

If a server is not running on UTC, things will break around DST changes (and I have experienced this in the past with other code). Adobe CF also used to do this, but they fixed it long ago - I don't think Lucee has any plans to fix.