### PR TITLE
Support an appRoot setting for relative filenames in stack frames

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -48,6 +48,7 @@ component {
 			'projectID' = 0,
 			'sentryUrl' = 'https://sentry.io',
 			'serverName' = cgi.server_name,
+			'appRoot' = expandPath('/'),
 			'sentryVersion' = 7,
 			// This is not arbityrary but must be a specific value. Leave as "cfml"
 			//  https://docs.sentry.io/development/sdk-dev/attributes/

--- a/models/SentryService.cfc
+++ b/models/SentryService.cfc
@@ -70,18 +70,18 @@ component accessors=true singleton {
 		// having the here as well, but this is so this service can be used outside
 		// of ColdBox and not require the ModuleConfig.cfc
 		return {
-		    // Enable the Sentry LogBox Appender Bridge
-		    'enableLogBoxAppender' = true,
-		    'async' = true,
-		    // Min/Max levels for appender
-		    'levelMin' = 'FATAL',
-		    'levelMax' = 'ERROR',
-		    // Enable/disable error logging
-		    'enableExceptionLogging' = true,
-		    // Data sanitization, scrub fields and headers, replaced with "[Filtered]" at runtime
-		    'scrubFields' 	= [ 'passwd', 'password', 'password_confirmation', 'secret', 'confirm_password', 'secret_token', 'APIToken', 'x-api-token', 'fwreinit' ],
-		    'scrubHeaders' 	= [ 'x-api-token', 'Authorization' ],
-		    'release' = '',
+			// Enable the Sentry LogBox Appender Bridge
+			'enableLogBoxAppender' = true,
+			'async' = true,
+			// Min/Max levels for appender
+			'levelMin' = 'FATAL',
+			'levelMax' = 'ERROR',
+			// Enable/disable error logging
+			'enableExceptionLogging' = true,
+			// Data sanitization, scrub fields and headers, replaced with "[Filtered]" at runtime
+			'scrubFields' 	= [ 'passwd', 'password', 'password_confirmation', 'secret', 'confirm_password', 'secret_token', 'APIToken', 'x-api-token', 'fwreinit' ],
+			'scrubHeaders' 	= [ 'x-api-token', 'Authorization' ],
+			'release' = '',
 			'environment' = 'production',
 			'DSN' = '',
 			'publicKey' = '',
@@ -89,6 +89,7 @@ component accessors=true singleton {
 			'projectID' = 0,
 			'sentryUrl' = 'https://sentry.io',
 			'serverName' = cgi.server_name,
+			'appRoot' = expandPath('/'),
 			'sentryVersion' = 7,
 			// This is not arbityrary but must be a specific value. Leave as "cfml"
 			//  https://docs.sentry.io/development/sdk-dev/attributes/
@@ -442,7 +443,7 @@ component accessors=true singleton {
 
 			var thisStackItem = {
 				"abs_path" 	= thisTCItem["TEMPLATE"],
-				"filename" 	= thisTCItem["TEMPLATE"],
+				"filename" 	= thisTCItem["TEMPLATE"].replace( variables.settings.appRoot, "" ).replace( "\", "/", "all" ),
 				"lineno" 	= thisTCItem["LINE"],
 				"pre_context" = [],
 				"context_line" = '',
@@ -743,8 +744,6 @@ component accessors=true singleton {
 				return "#key#=#value#";
 		} );
 		return arrayToList( aTarget, "&" );
-	}
-
-
+	}	
 
 }

--- a/models/SentryService.cfc
+++ b/models/SentryService.cfc
@@ -146,6 +146,8 @@ component accessors=true singleton {
 		setPlatform( settings.platform );
 		
 		setUserInfoUDF( settings.userInfoUDF );
+
+		settings.appRoot = normalizeSlashes( settings.appRoot );
 	}
 
 	/**
@@ -443,7 +445,7 @@ component accessors=true singleton {
 
 			var thisStackItem = {
 				"abs_path" 	= thisTCItem["TEMPLATE"],
-				"filename" 	= thisTCItem["TEMPLATE"].replace( variables.settings.appRoot, "" ).replace( "\", "/", "all" ),
+				"filename" 	= normalizeSlashes(thisTCItem["TEMPLATE"]).replace(variables.settings.appRoot, ""),
 				"lineno" 	= thisTCItem["LINE"],
 				"pre_context" = [],
 				"context_line" = '',
@@ -745,5 +747,18 @@ component accessors=true singleton {
 		} );
 		return arrayToList( aTarget, "&" );
 	}	
+
+	/**
+	 * Turns all slashes in a path to forward slashes except for \\ in a Windows UNC network share
+	 * Also changes double slashes to a single slash
+	 * @path The path to normalize
+	 */
+	function normalizeSlashes( string path ) {
+		var normalizedPath = arguments.path.replace( "\", "/", "all" );
+		if( arguments.path.left( 2 ) == "\\" ) {
+			normalizedPath = "\\" & normalizedPath.mid( 3, normalizedPath.len() - 2 );
+		} 
+		return normalizedPath.replace( "//", "/", "all" );	
+	}
 
 }

--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,9 @@ settings = {
   sentryUrl : 'https://sentry.io',
   // name of your server
   serverName : cgi.server_name,
+  // Absolute path to the root of your app, defaults to the webroot.
+  // files in stacktrace frames contained under this path will be reported relative to it
+  appRoot : expandPath('/'),
   // Default logger category. LogBox appender will pass through the LogBox category name 
   logger : 'sentry',
   // Closure to return dynamic info of logged in user which will appear in Sentry error reports under "User".


### PR DESCRIPTION
Here is an attempt at implementing #2 - in my testing this works the way I would like. I added an `appRoot` setting that is blank by default, and in which case everything stays the same as it is now, or you can pass an absolute path, and then template paths in the stack trace will be sent as paths relative to it.

Obviously I would be happy to rename the setting or the new function if you like.