### PR TITLE
Get first IP of X-Forwarded-For

### DIFF
--- a/models/SentryService.cfc
+++ b/models/SentryService.cfc
@@ -686,7 +686,7 @@ component accessors=true singleton {
 			return trim( listLast( headers[ 'x-cluster-client-ip' ] ) );
 		}
 		if( structKeyExists( headers, 'X-Forwarded-For' ) ){
-			return trim( listLast( headers[ 'X-Forwarded-For' ] ) );
+			return trim( listFirst( headers[ 'X-Forwarded-For' ] ) );
 		}
 
 		return len( cgi.remote_addr ) ? trim( listLast( cgi.remote_addr ) ) : '127.0.0.1';


### PR DESCRIPTION
When going through a proxy that sets the X-Forwarded-for header, the client ip address is the first one, not the last.

The general format of the field is:
    X-Forwarded-For: client, proxy1, proxy2

See: https://en.wikipedia.org/wiki/X-Forwarded-For