### PR TITLE
ACF fix for array assignments

### DIFF
--- a/models/SentryService.cfc
+++ b/models/SentryService.cfc
@@ -462,30 +462,28 @@ component accessors=true singleton {
 			// for source code rendering
 			var fileLen = arrayLen( fileArray );
 			var errorLine = thisTCItem[ "LINE" ];
-			var pre_context = thisStackItem["pre_context"];
-			var post_context = thisStackItem["post_context"];
-			
+
 			if (errorLine-3 >= 1 && errorLine-3 <= fileLen ) {
-				pre_context[1] = fileArray[errorLine-3];
+				thisStackItem.pre_context[1] = fileArray[errorLine-3];
 			}
 			if (errorLine-2 >= 1 && errorLine-2 <= fileLen) {
-				pre_context[1] = fileArray[errorLine-2];
+				thisStackItem.pre_context[1] = fileArray[errorLine-2];
 			}
 			if (errorLine-1 >= 1 && errorLine-1 <= fileLen) {
-				pre_context[2] = fileArray[errorLine-1];
+				thisStackItem.pre_context[2] = fileArray[errorLine-1];
 			}
-			
+
 			if (errorLine <= fileLen) {
 				thisStackItem["context_line"] = fileArray[errorLine];
 			}
-			
+
 			if (fileLen >= errorLine+1) {
-				post_context[1] = fileArray[errorLine+1];
+				thisStackItem.post_context[1] = fileArray[errorLine+1];
 			}
 			if (fileLen >= errorLine+2) {
-				post_context[2] = fileArray[errorLine+2];
+				thisStackItem.post_context[2] = fileArray[errorLine+2];
 			}
-				
+
 			sentryException["sentry.interfaces.Stacktrace"]["frames"][stacki] = thisStackItem;
 		}
 		


### PR DESCRIPTION
The following does not modify the `thisStackItem.pre_context` array on ACF.
```cfc
var pre_context = thisStackItem["pre_context"];
pre_context[1] = 'anything';
```

While I am looking at these lines, I will admit I am unclear about this section:
```cfc
if (errorLine-3 >= 1 && errorLine-3 <= fileLen ) {
    thisStackItem.pre_context[1] = fileArray[errorLine-3];
}
if (errorLine-2 >= 1 && errorLine-2 <= fileLen) {
    thisStackItem.pre_context[1] = fileArray[errorLine-2];
}
```
I am having trouble imagining a scenario where the first condition passes and not the second (which overwrites it). Since `errorLine` is presumably in the fileArray, any index less than it and above zero should also be in the file array.

Also, at least on ACF2016, with its `serializeJSON()` problems, I have seen Sentry complain about numeric values in the cookies - the code already uses `toString()` on them, so I am not sure that anything more can be done there - ACF2016 just insists on converting anything to a number that it thinks it can.