### PR TITLE
Add funcLineNums as a dependency

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -17,6 +17,7 @@ component {
 	this.viewParentLookup 	= true;
 	// If true, looks for layouts in the parent first, if not found, then in module. Else vice-versa
 	this.layoutParentLookup = true;
+	this.dependencies = [ 'funclinenums' ];
 
 	// STATIC SCRUB FIELDS
 	variables.SCRUB_FIELDS 	= [ 'passwd', 'password', 'password_confirmation', 'secret', 'confirm_password', 'secret_token', 'APIToken', 'x-api-token', 'fwreinit' ];

--- a/box.json
+++ b/box.json
@@ -20,7 +20,9 @@
         }
     ],
     "contributors":[],
-    "dependencies":{},
+    "dependencies":{
+        "funclinenums":"^1.1.0"
+    },
     "devDependencies":{},
     "installPaths":{},
     "ignore":[

--- a/models/SentryService.cfc
+++ b/models/SentryService.cfc
@@ -11,6 +11,7 @@ component accessors=true singleton {
 	property name="settings" inject="coldbox:moduleSettings:sentry";
 	property name="moduleConfig" inject="coldbox:moduleConfig:sentry";
 	property name="controller" inject="coldbox";
+	property name="functionLineNums" inject="functionLineNums@funclinenums";
 
 	property name="levels" type="array";
 
@@ -148,6 +149,18 @@ component accessors=true singleton {
 		setUserInfoUDF( settings.userInfoUDF );
 
 		settings.appRoot = normalizeSlashes( settings.appRoot );
+
+		// in a non ColdBox context, ensure functionLineNums exists
+		// so this service can still be used if functionLineNums 
+		// is not passed in
+		if (isNull(variables.functionLineNums)) {
+			setFunctionLineNums({
+				findTagContextFunction: function() {
+					return '';
+				}
+			});
+		}
+
 	}
 
 	/**
@@ -453,10 +466,9 @@ component accessors=true singleton {
 			};
 
 			// The name of the function being called
-			if (i == 1) {
-				thisStackItem["function"] = "column #thisTCItem["COLUMN"]#";
-			} else {
-				thisStackItem["function"] = thisTCItem["ID"];
+			var functionName = functionLineNums.findTagContextFunction(thisTCItem);
+			if (len(functionName)) {
+				thisStackItem["function"] = functionName;
 			}
 
 			// for source code rendering

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,13 @@ application.sentryService.captureMessage( 'winter is coming', 'warning' );
 application.sentryService.captureException( exception=cfcatch, additionalData={ anything : 'here' } );
 ```
 
+This module makes use of the `funclinenums` module for the purpose of computing and reporting CFML function names in a stack trace. If you installed this via CommandBox, `funclinenums` was installed as a dependency for you. In a ColdBox app you don't need to do anything more, as WireBox will take care of wiring it up for you. However, in a non ColdBox app, if you want CFML function names reported in your stack trace you will need to add it to the `SentryService` yourself.
+
+```cfc
+functionLineNums = new modules.sentry.modules.funclinenums.functionLineNums();
+application.sentryService.setFunctionLineNums(functionLineNums);
+```
+
 ## LogBox Standalone Installation
 
 If your app doesn't use ColdBox but does use LogBox, you can use our `SentryAppender` class in your LogBox config.  You'll need to still instantiate the `SentryService` the same as above, but then you can just use the standard LogBox API to send your messages.


### PR DESCRIPTION
Add the computing of function names in stack trace frames, addressing #6. I added a try/catch with logging in the `funclinenums` module [here](https://github.com/jcberquist/function-linenums/blob/master/functionLineNums.cfc#L86-L94) so if something goes wrong with a parse, it won't kill any requests. I didn't add a setting or anything to turn this off in a ColdBox app, is that something you would like to see?