### PR TITLE
If form is empty, check for JSON body being passed in

### DIFF
--- a/models/SentryService.cfc
+++ b/models/SentryService.cfc
@@ -614,7 +614,7 @@ component accessors=true singleton {
 			"sessions" 		: thisSession,
 			"url" 			: arguments.path,
 			"method" 		: arguments.cgiVars.request_method,
-			"data" 			: sanitizeFields( form ),
+			"data" 			: !isEmpty( form ) ? sanitizeFields( form ) : sanitizeFields( isJSON( getHTTPRequestData().content ) ? deserializeJSON( getHTTPRequestData().content ) : {} ),
 			"query_string" 	: sanitizeQueryString( arguments.cgiVars.query_string ),
 							// Sentry requires all cookies be strings
 			"cookies" 		: cookie.map( function( k, v ) {


### PR DESCRIPTION
If we have an API endpoint that's receiving a json body, assuming the form scope is empty, then let's pass a sanitized version of the json body through to Sentry.