### PR TITLE
Move `:` out of the third segment

### DIFF
--- a/models/SentryService.cfc
+++ b/models/SentryService.cfc
@@ -173,7 +173,7 @@ component accessors=true singleton {
 	* https://docs.sentry.io/clientdev/overview/#parsing-the-dsn
 	*/
 	private void function parseDSN(required string DSN) {
-		var pattern = "^(?:(\w+):)?\/\/(\w+):(\w+)?@([\w\.\-:]+)\/(.*)";
+		var pattern = "^(?:(\w+):)?\/\/(\w+):?(\w+)?@([\w\.\-:]+)\/(.*)";
 		var result 	= reFind(pattern,arguments.DSN,1,true);
 		var segments = [];
 

--- a/models/SentryService.cfc
+++ b/models/SentryService.cfc
@@ -173,7 +173,7 @@ component accessors=true singleton {
 	* https://docs.sentry.io/clientdev/overview/#parsing-the-dsn
 	*/
 	private void function parseDSN(required string DSN) {
-		var pattern = "^(?:(\w+):)?\/\/(\w+)(:\w+)?@([\w\.\-:]+)\/(.*)";
+		var pattern = "^(?:(\w+):)?\/\/(\w+):(\w+)?@([\w\.\-:]+)\/(.*)";
 		var result 	= reFind(pattern,arguments.DSN,1,true);
 		var segments = [];
 


### PR DESCRIPTION
This fixes the privateKey which currently ends up with the colon (ex. `:abcdefg`) in it.  We only want the `abcdefg` portion.