### PR TITLE
Update SentryService Session setting

### DIFF
--- a/models/SentryService.cfc
+++ b/models/SentryService.cfc
@@ -628,7 +628,7 @@ component accessors=true singleton {
 		}
 
 		var thisSession = {};
-		if( GetApplicationMetadata().SessionManagement ?: false ) {
+		if( ( GetApplicationMetadata().SessionManagement ?: false ) && !isNull( session ) ) {
 			thisSession = session;
 		}
 


### PR DESCRIPTION
On a weird occurrence that the service fires off before the session is available it errors out. This handles the additional check to make sure that the Session scope exists.