### PR TITLE
Fix for ACF compatibility - Exception is not recognized as Struct

### DIFF
--- a/models/SentryAppender.cfc
+++ b/models/SentryAppender.cfc
@@ -56,7 +56,7 @@ component extends="coldbox.system.logging.AbstractAppender" accessors=true{
 				
 		} else if( 
 			( isStruct( extraInfo ) || isObject( extraInfo ) )
-            && isStruct( extraInfo.exception ) && extraInfo.exception.keyExists( "StackTrace" ) 
+			&& extraInfo.keyExists( "exception" ) && isStruct( extraInfo.exception ) && extraInfo.exception.keyExists( "StackTrace" ) 
 		){
 			
 			var trimmedExtra = structCopy( extraInfo );

--- a/models/SentryAppender.cfc
+++ b/models/SentryAppender.cfc
@@ -42,7 +42,10 @@ component extends="coldbox.system.logging.AbstractAppender" accessors=true{
 		}
 	
 		// Is this an exception or not?
-		if( isStruct( extraInfo ) && extraInfo.keyExists( "StackTrace" ) && extraInfo.keyExists( "message" ) && extraInfo.keyExists( "detail" ) ){
+		if( 
+			( isStruct( extraInfo ) || isObject( extraInfo ) )
+            && extraInfo.keyExists( "message" ) && extraInfo.keyExists( "detail" ) 
+		){
 			
 			getProperty( 'sentryService' ).captureException(
 				exception = extraInfo,
@@ -51,7 +54,10 @@ component extends="coldbox.system.logging.AbstractAppender" accessors=true{
 				logger = loggerCat
 			);
 				
-		} else if( isStruct( extraInfo ) && extraInfo.keyExists( "exception" ) && isStruct( extraInfo.exception ) && extraInfo.exception.keyExists( "StackTrace" ) ){
+		} else if( 
+			( isStruct( extraInfo ) || isObject( extraInfo ) )
+            && isStruct( extraInfo.exception ) && extraInfo.exception.keyExists( "StackTrace" ) 
+		){
 			
 			var trimmedExtra = structCopy( extraInfo );
 			trimmedExtra.delete( 'exception' );

--- a/models/SentryAppender.cfc
+++ b/models/SentryAppender.cfc
@@ -44,7 +44,7 @@ component extends="coldbox.system.logging.AbstractAppender" accessors=true{
 		// Is this an exception or not?
 		if( 
 			( isStruct( extraInfo ) || isObject( extraInfo ) )
-            && extraInfo.keyExists( "message" ) && extraInfo.keyExists( "detail" ) 
+            && extraInfo.keyExists( "StackTrace" ) && extraInfo.keyExists( "message" ) && extraInfo.keyExists( "detail" ) 
 		){
 			
 			getProperty( 'sentryService' ).captureException(


### PR DESCRIPTION
ACF does not recognize a CFML exception object as a struct, as outlined in this blog post: http://blog.adamcameron.me/2015/05/cfml-what-manner-of-object-should.html

This updated conditional will ensure that ACF does not log everything as a message