### PR TITLE
If ExtendedInfo looks like JSON, treat it like it

### DIFF
--- a/models/SentryService.cfc
+++ b/models/SentryService.cfc
@@ -466,7 +466,7 @@ component accessors=true singleton {
 		
 		// Applies to type = "application" and "custom". Custom error message; information that the default exception handler does not display.
 		if( structKeyExists( arguments.exception, 'ExtendedInfo' ) && len( arguments.exception.ExtendedInfo ) ) {
-			sentryExceptionExtra[ "application" ][ "Extended Info" ] = arguments.exception.ExtendedInfo;
+			sentryExceptionExtra[ "application" ][ "Extended Info" ] = isJSON( arguments.exception.ExtendedInfo ) ? deserializeJSON( arguments.exception.ExtendedInfo ) : arguments.exception.ExtendedInfo;
 		}
 		
 		if (structCount(sentryExceptionExtra))


### PR DESCRIPTION
Because the ExtendedInfo in a throw has to be a string, it makes it hard to read in Sentry's UI when it's actually a struct.