### PR TITLE
Fix getRealIP() to use listFirst instead of listLast

### DIFF
--- a/models/SentryService.cfc
+++ b/models/SentryService.cfc
@@ -764,7 +764,7 @@ component accessors=true singleton {
 			return trim( listFirst( headers[ 'X-Forwarded-For' ] ) );
 		}
 
-		return len( cgi.remote_addr ) ? trim( listLast( cgi.remote_addr ) ) : '127.0.0.1';
+		return len( cgi.remote_addr ) ? trim( listFirst( cgi.remote_addr ) ) : '127.0.0.1';
 	}
 	
 


### PR DESCRIPTION
If we end up with a list of IP addresses, then we only want the first one which will be the requesting user's IP.