### PR TITLE
Add ability to append arbitrary extra info on every capture

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -56,7 +56,8 @@ component {
 			//  https://docs.sentry.io/development/sdk-dev/attributes/
 			'platform' = 'cfml',
 			'logger' = (!isNull( controller ) ? controller.getSetting( 'appName' ) : 'sentry' ),
-			'userInfoUDF' = ''
+			'userInfoUDF' = '',
+			'extraInfoUDFs' = {}
 		};
 		
 		// Try to look up the release based on a box.json

--- a/test-harness/tests/specs/SentryTests.cfc
+++ b/test-harness/tests/specs/SentryTests.cfc
@@ -88,6 +88,21 @@ component extends='coldbox.system.testing.BaseTestCase' appMapping='/root'{
 				}).toThrow( 'ThrownFromMain' );
 			});
 
+			it( 'can log a message with extra info automatically added', function(){
+				var service = prepareMock( getSentry() );
+				service.setEnabled( true );
+				service.$( "post" );
+
+				service.addExtraInfoUdf( "queries", function() {
+					return [ "foo", "bar" ];
+				} );
+				service.addExtraInfoUdf( "qb", function() {
+					return [ "foo", "bar" ];
+				} );
+				service.captureMessage( 'This is a test message' );
+				writeDump( var = service.$callLog( "post" ) );
+			});
+
 		});
 	}
 


### PR DESCRIPTION
It would be very handy to have some data automatically captured whenever we send a message Sentry.  This enables a dictionary of names to udfs that will populate the `extra` scope automatically in the `capture` method.  These can be defined in settings using `extraInfoUdfs` (struct) or added ad-hoc using the `addExtraInfoUdf( required string name, required function udf )`.