### PR TITLE
Add throwOnPostError setting to throw exception

### DIFF
--- a/models/SentryService.cfc
+++ b/models/SentryService.cfc
@@ -105,7 +105,8 @@ component accessors=true singleton {
 			'logger' = 'sentry',
 			'userInfoUDF' = '',
 			'extraInfoUdfs' = {},
-			'showJavaStackTrace' = false
+			'showJavaStackTrace' = false,
+			'throwOnPostError' = false
 		};
 	}
 
@@ -734,11 +735,13 @@ component accessors=true singleton {
 			cfhttpparam(type="body",value=arguments.json);
 		}
 
-		if( find( "400", http.statuscode ) || find( "500", http.statuscode ) ){
-			writeDump( var="Error posting to Sentry: #http.statuscode# - #left( http.filecontent, 1000 )#", output='console' );
-		// TODO : Honor Sentry’s HTTP 429 Retry-After header any other errors
-		} else if (!find("200",http.statuscode)){
-			writeDump( var="Error posting to Sentry: #http.statuscode# - #left( http.filecontent, 1000 )#", output='console' );
+		if( find( "400", http.statuscode ) || find( "500", http.statuscode ) || !find("200",http.statuscode) ){
+			if ( settings.throwOnPostError ) {
+				throw( message="Error posting to Sentry: #http.statuscode#", detail=http.filecontent );
+			} else {
+				writeDump( var="Error posting to Sentry: #http.statuscode# - #left( http.filecontent, 1000 )#", output='console' );
+			}
+			// TODO : Honor Sentry’s HTTP 429 Retry-After header any other errors
 		}
 	}
 


### PR DESCRIPTION
If the sentry endpoint is returning an error, it is hard to debug what is going on, the dump was not being output even when async=false.