### PR TITLE
Update SentryService.cfc

### DIFF
--- a/models/SentryService.cfc
+++ b/models/SentryService.cfc
@@ -629,7 +629,7 @@ component accessors=true singleton {
 		var signature       = "";
 		var header          = "";
 		var timeVars        = getTimeVars();
-		var httpRequestData = getHTTPRequestData();
+		var httpRequestData = getHTTPDataForRequest();
 
 		// Add global metadata
 		arguments.captureStruct[ "event_id" ]    = lCase( replace( createUUID(), "-", "", "all" ) );
@@ -869,7 +869,7 @@ component accessors=true singleton {
 	 * Get Real IP, by looking at clustered, proxy headers and locally.
 	 */
 	private function getRealIP(){
-		var headers = getHTTPRequestData().headers;
+		var headers = getHTTPDataForRequest().headers;
 
 		// When going through a proxy, the IP can be a delimtied list, thus we take the last one in the list
 
@@ -980,6 +980,20 @@ component accessors=true singleton {
 			normalizedPath = "\\" & normalizedPath.mid( 3, normalizedPath.len() - 2 );
 		}
 		return normalizedPath.replace( "//", "/", "all" );
+	}
+
+	/**
+	 * I return the http request data
+	 */
+	struct function getHTTPDataForRequest() {
+		try {
+			var result = getHTTPRequestData();
+			if ( !isNull( result ) ) {
+				return result;
+			}
+		} catch ( any e ) {
+		}
+		return { "headers" : {}, "content" : "" };
 	}
 
 }


### PR DESCRIPTION
Handle when getHTTPRequestData is null
Happens when called via java.util.concurrent.CompletableFuture