### PR TITLE
Handle position 0 error on context_line

### DIFF
--- a/models/SentryService.cfc
+++ b/models/SentryService.cfc
@@ -561,7 +561,7 @@ component accessors=true singleton {
 				thisStackItem.pre_context[ 3 ] = fileArray[ errorLine - 1 ];
 			}
 
-			if ( errorLine <= fileLen ) {
+			if ( errorLine <= fileLen && fileLen > 0 && errorLine >= 1 ) {
 				thisStackItem[ "context_line" ] = fileArray[ errorLine ];
 			}
 


### PR DESCRIPTION
To prevent the errorLine is 0 or fileLen is 0 from throwing an error, additional conditions has been added for setting the context_line value.

This is related to previous pull request #30 