### PR TITLE
Capture stack trace in additionalData struct

### DIFF
--- a/models/SentryAppender.cfc
+++ b/models/SentryAppender.cfc
@@ -48,11 +48,16 @@ component extends="coldbox.system.logging.AbstractAppender" accessors=true {
 				"detail"
 			)
 		) {
+			var additionalData = {};
+			if ( extraInfo.keyExists( "StackTrace" ) ) {
+				additionalData.stacktrace = extraInfo.StackTrace;
+			}
 			getProperty( "sentryService" ).captureException(
-				exception = extraInfo,
-				level     = level,
-				message   = message,
-				logger    = loggerCat
+				exception      = extraInfo,
+				level          = level,
+				message        = message,
+				logger         = loggerCat,
+				additionalData = additionalData
 			);
 		} else if (
 			( isStruct( extraInfo ) || isObject( extraInfo ) )
@@ -62,6 +67,9 @@ component extends="coldbox.system.logging.AbstractAppender" accessors=true {
 		) {
 			var trimmedExtra = structCopy( extraInfo );
 			trimmedExtra.delete( "exception" );
+			if ( extraInfo.exception.keyExists( "StackTrace" ) ) {
+				trimmedExtra.stacktrace = extraInfo.exception.StackTrace;
+			}
 
 			getProperty( "sentryService" ).captureException(
 				exception      = extraInfo.exception,


### PR DESCRIPTION
# Description

The caught exception is not showing the stack trace in Sentry. Save the stack trace under `additionalData` so it will at least render in Sentry as a string.

## Issues

https://ortussolutions.atlassian.net/browse/BOX-160

## Type of change

Please delete options that are not relevant.

- [x] Bug Fix

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
