### PR TITLE
handle null value

### DIFF
--- a/models/SentryService.cfc
+++ b/models/SentryService.cfc
@@ -718,7 +718,9 @@ component accessors=true singleton {
 			if ( listFindNoCase( "id,email,ip_address,username", key ) ) {
 				key = lCase( key );
 			}
-			correctCasingUserInfo[ key ] = thisUserInfo[ key ];
+			if(!isNull(thisUserInfo[ key ])) {
+				correctCasingUserInfo[ key ] = thisUserInfo[ key ];
+			}
 		}
 
 		arguments.captureStruct[ "user" ] = correctCasingUserInfo;


### PR DESCRIPTION
addresses the exception:
expression Error: the value from key [accessor] is NULL, which is the same as not existing in CFML (/distrocore/forgebox/sentry/models/SentryService.cfc:721) the value from key [accessor] is NULL, which is the same as not existing in CFML

